### PR TITLE
MultiPaper / Folia / ShreddedPaper support.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,22 +31,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/common/src/main/java/net/skullian/skyfactions/common/api/FactionAPI.java
+++ b/common/src/main/java/net/skullian/skyfactions/common/api/FactionAPI.java
@@ -33,7 +33,7 @@ public abstract class FactionAPI {
      * @param name   Name of the faction.
      */
     public void createFaction(SkyUser player, String name) {
-        SkyApi.getInstance().getDatabaseManager().getFactionsManager().registerFaction(player, name).whenComplete((ignored, ex) -> {
+        SkyApi.getInstance().getDatabaseManager().getFactionsManager().registerFaction(player, name).whenCompleteAsync((ignored, ex) -> {
             if (ex != null) {
                 ErrorUtil.handleError(player, "create a new Faction", "SQL_FACTION_CREATE", ex);
                 // todo disband faction?
@@ -42,7 +42,7 @@ public abstract class FactionAPI {
             // Creating & Registering the island in the database before getting the Faction.
             // This stops the Faction retrieval returning null for the island, and causing issues, seeing as the Faction
             // is immediately cached.
-            createIsland(player, name);
+            createIsland(player, name).join();
 
             SkyApi.getInstance().getFactionAPI().getFaction(name).whenComplete((faction, exc) -> {
                 if (exc != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,6 +34,7 @@ jooq=3.19.15
 jetbrains_annotations=26.0.1
 guava=33.4.0-jre
 apache_commons=3.17.0
+multilib=1.2.4
 
 # Plugins
 jukebox=1.20.8

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -96,6 +96,11 @@ repositories {
         name = "PlayPro Repository"
         url = "https://maven.playpro.com/"
     }
+
+    maven {
+        name = "MultiPaper (MultiLib) Repository"
+        url = "https://repo.clojars.org/"
+    }
 }
 
 dependencies {
@@ -106,6 +111,7 @@ dependencies {
     compileOnly("org.incendo:cloud-paper:${cloud}-SNAPSHOT")
     compileOnly("xyz.xenondevs.invui:invui:${invui}")
     compileOnly("net.kyori:adventure-platform-bukkit:${adventure_bukkit}")
+    compileOnly("com.github.puregero:multilib:${multilib}")
 
     implementation(platform("com.intellectualsites.bom:bom-newest:${fawe_bom}")) {
         exclude group : "com.google.guava", module: "guava"

--- a/paper/build.gradle
+++ b/paper/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     compileOnly(project(":common"))
     compileOnly(project(":modules:discord"))
 
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:${minecraft_version}-R0.1-SNAPSHOT")
     compileOnly("org.incendo:cloud-paper:${cloud}-SNAPSHOT")
     compileOnly("xyz.xenondevs.invui:invui:${invui}")
     compileOnly("net.kyori:adventure-platform-bukkit:${adventure_bukkit}")

--- a/paper/src/main/java/net/skullian/skyfactions/paper/SkyLoader.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/SkyLoader.java
@@ -47,6 +47,7 @@ public class SkyLoader implements PluginLoader {
         centralResolver.addDependency(new Dependency(new DefaultArtifact("org.jooq:jooq:3.19.16"), null));
         centralResolver.addDependency(new Dependency(new DefaultArtifact("org.flywaydb:flyway-core:11.1.0"), null));
         centralResolver.addDependency(new Dependency(new DefaultArtifact("com.google.guava:guava:33.3.1-jre"), null));
+        centralResolver.addDependency(new Dependency(new DefaultArtifact("com.github.puregero:multilib:1.2.4"), null));
 
 
         pluginClasspathBuilder.addLibrary(invUIResolver);

--- a/paper/src/main/java/net/skullian/skyfactions/paper/SkyLoader.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/SkyLoader.java
@@ -47,10 +47,16 @@ public class SkyLoader implements PluginLoader {
         centralResolver.addDependency(new Dependency(new DefaultArtifact("org.jooq:jooq:3.19.16"), null));
         centralResolver.addDependency(new Dependency(new DefaultArtifact("org.flywaydb:flyway-core:11.1.0"), null));
         centralResolver.addDependency(new Dependency(new DefaultArtifact("com.google.guava:guava:33.3.1-jre"), null));
-        centralResolver.addDependency(new Dependency(new DefaultArtifact("com.github.puregero:multilib:1.2.4"), null));
+
+
+        MavenLibraryResolver multiLibResolver = new MavenLibraryResolver();
+        multiLibResolver.addRepository(new RemoteRepository.Builder("multipaper", "default", "https://repo.clojars.org/").build());
+
+        multiLibResolver.addDependency(new Dependency(new DefaultArtifact("com.github.puregero:multilib:1.2.4"), null));
 
 
         pluginClasspathBuilder.addLibrary(invUIResolver);
         pluginClasspathBuilder.addLibrary(centralResolver);
+        pluginClasspathBuilder.addLibrary(multiLibResolver);
     }
 }

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotFactionAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotFactionAPI.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.api;
 
+import com.github.puregero.multilib.MultiLib;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldguard.WorldGuard;
@@ -33,7 +34,7 @@ public class SpigotFactionAPI extends FactionAPI {
 
     @Override
     public void handleFactionWorldBorder(SkyUser player, FactionIsland island) {
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> {
             SkyLocation center = island.getCenter(null);
 
             SkyApi.getInstance().getWorldBorderAPI().setWorldBorder(player, (island.getSize() * 2), new BorderPos(center.getX(), center.getZ()));

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotObeliskAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotObeliskAPI.java
@@ -125,7 +125,7 @@ public class SpigotObeliskAPI extends ObeliskAPI {
 
         for (World world : worlds) {
             for (ItemDisplay entity : world.getEntitiesByClass(ItemDisplay.class)) {
-                if (!entity.getPersistentDataContainer().has(PaperSharedConstants.OBELISK_KEY) || MultiLib.isChunkExternal(entity)) return;
+                if (!entity.getPersistentDataContainer().has(PaperSharedConstants.OBELISK_KEY) || MultiLib.isChunkExternal(entity)) continue;
 
                 Location location = getLocationFromEntity(entity.getLocation());
                 SpigotObeliskBlockEntity blockEntity = new SpigotObeliskBlockEntity();

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotObeliskAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotObeliskAPI.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.api;
 
+import com.github.puregero.multilib.MultiLib;
 import com.jeff_media.customblockdata.CustomBlockData;
 import lombok.Getter;
 import net.skullian.skyfactions.common.api.ObeliskAPI;
@@ -29,7 +30,7 @@ public class SpigotObeliskAPI extends ObeliskAPI {
 
     @Override
     public void spawnPlayerObelisk(SkyUser player, SkyIsland island) {
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> {
             World world = Bukkit.getWorld(Settings.ISLAND_PLAYER_WORLD.getString());
             if (world != null) {
                 SkyLocation center = island.getCenter(world.getName());
@@ -55,7 +56,7 @@ public class SpigotObeliskAPI extends ObeliskAPI {
 
     @Override
     public void spawnFactionObelisk(String faction, SkyIsland island) {
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> {
             World world = Bukkit.getWorld(Settings.ISLAND_FACTION_WORLD.getString());
             if (world != null) {
                 SkyLocation center = island.getCenter(world.getName());

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotObeliskAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotObeliskAPI.java
@@ -125,7 +125,7 @@ public class SpigotObeliskAPI extends ObeliskAPI {
 
         for (World world : worlds) {
             for (ItemDisplay entity : world.getEntitiesByClass(ItemDisplay.class)) {
-                if (!entity.getPersistentDataContainer().has(PaperSharedConstants.OBELISK_KEY)) return;
+                if (!entity.getPersistentDataContainer().has(PaperSharedConstants.OBELISK_KEY) || MultiLib.isChunkExternal(entity)) return;
 
                 Location location = getLocationFromEntity(entity.getLocation());
                 SpigotObeliskBlockEntity blockEntity = new SpigotObeliskBlockEntity();

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotPlayerAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotPlayerAPI.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.api;
 
+import com.github.puregero.multilib.MultiLib;
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.skullian.skyfactions.common.api.PlayerAPI;
 import net.skullian.skyfactions.common.api.SkyApi;
@@ -8,7 +9,6 @@ import net.skullian.skyfactions.common.util.SkyItemStack;
 import net.skullian.skyfactions.paper.api.adapter.SpigotAdapter;
 import net.skullian.skyfactions.paper.hooks.ItemJoinHook;
 import net.skullian.skyfactions.paper.util.DependencyHandler;
-import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -67,7 +67,7 @@ public class SpigotPlayerAPI extends PlayerAPI {
 
     @Override
     public List<SkyUser> getOnlinePlayers() {
-        return Bukkit.getOnlinePlayers().stream().map(player -> SkyApi.getInstance().getUserManager().getUser(player.getUniqueId())).toList();
+        return MultiLib.getAllOnlinePlayers().stream().map(player -> SkyApi.getInstance().getUserManager().getUser(player.getUniqueId())).toList();
     }
 
     @Override

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotRegionAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotRegionAPI.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.api;
 
+import com.github.puregero.multilib.MultiLib;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
@@ -101,7 +102,7 @@ public class SpigotRegionAPI extends RegionAPI {
 
     @Override
     public void modifyWorldBorder(SkyUser player, SkyLocation center, int size) {
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> {
             SkyApi.getInstance().getWorldBorderAPI().setWorldBorder(player, (size * 2), new BorderPos(center.getX(), center.getZ()));
         });
     }

--- a/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotSkyAPI.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/api/SpigotSkyAPI.java
@@ -134,6 +134,9 @@ public final class SpigotSkyAPI extends SkyApi {
         commandHandler = new SpigotCommandHandler();
         pluginInfoAPI = new SpigotPluginInfoAPI();
 
+        SLogger.info("Preloading Obelisks.");
+        obeliskAPI.preLoad();
+
         SkyModuleManager.registerModule(DiscordModule.class);
 
         SLogger.setup("Loading InvLib Instance.", false);

--- a/paper/src/main/java/net/skullian/skyfactions/paper/defence/SpigotDefence.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/defence/SpigotDefence.java
@@ -2,6 +2,7 @@ package net.skullian.skyfactions.paper.defence;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.puregero.multilib.MultiLib;
 import com.jeff_media.customblockdata.CustomBlockData;
 import io.lumine.mythic.bukkit.MythicBukkit;
 import net.skullian.skyfactions.common.api.SkyApi;
@@ -105,9 +106,8 @@ public abstract class SpigotDefence extends Defence {
             if (nearbyEntities.isEmpty()) return new ArrayList<>();
 
             List<LivingEntity> filteredEntities = filterEntities(nearbyEntities);
-            List<Object> chosenEntities = selectRandomEntities(filteredEntities);
 
-            return chosenEntities;
+            return selectRandomEntities(filteredEntities);
         } else {
             SLogger.fatal("Could not find world [{}] for defence [{}].", defenceWorld, getStruct().getIDENTIFIER());
             return new ArrayList<>();
@@ -123,6 +123,8 @@ public abstract class SpigotDefence extends Defence {
         getTargetedEntities().removeIf(currentlyTargeted -> entities.stream().noneMatch(entity -> entity.getUniqueId().equals(currentlyTargeted)));
 
         for (LivingEntity entity : entities) {
+            if (MultiLib.isChunkExternal(entity)) continue;
+
             if (isEntityAllowed(entity, allowedEntities, shouldBlockNPCS, blockedMythicMobs)) {
                 filteredEntities.add(entity);
             }

--- a/paper/src/main/java/net/skullian/skyfactions/paper/defence/defences/ArrowDefence.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/defence/defences/ArrowDefence.java
@@ -1,11 +1,11 @@
 package net.skullian.skyfactions.paper.defence.defences;
 
+import com.github.puregero.multilib.MultiLib;
 import net.skullian.skyfactions.common.defence.struct.DefenceData;
 import net.skullian.skyfactions.common.defence.struct.DefenceStruct;
 import net.skullian.skyfactions.paper.SkyFactionsReborn;
 import net.skullian.skyfactions.paper.api.adapter.SpigotAdapter;
 import net.skullian.skyfactions.paper.defence.SpigotDefence;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.*;
@@ -27,7 +27,7 @@ public class ArrowDefence extends SpigotDefence {
         }
 
         //✨✨ hacky!!
-        setTask(getService().scheduleAtFixedRate(() -> Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+        setTask(getService().scheduleAtFixedRate(() -> MultiLib.getAsyncScheduler().runNow(SkyFactionsReborn.getInstance(), (consumer) -> {
             if (!isAllowed(getStruct().getPROJECTILE()) || !canShoot()) return;
 
             List<Object> entities = getRandomEntity(getDefenceLocation().getWorldName());

--- a/paper/src/main/java/net/skullian/skyfactions/paper/event/armor/ArmorListener.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/event/armor/ArmorListener.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.event.armor;
 
+import com.github.puregero.multilib.MultiLib;
 import net.skullian.skyfactions.paper.SkyFactionsReborn;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -97,7 +98,7 @@ public class ArmorListener implements Listener {
                     // Only cancel the armor to collect.
                     if (armorEvent.isCancelled()) {
                         holding.setAmount(holding.getAmount() - armorEvent.getItem().getAmount());
-                        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+                        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> {
                             p.getInventory().setItem(armorEvent.getArmorSlot(), armorEvent.getItem());
                             p.updateInventory();
                         });
@@ -120,7 +121,7 @@ public class ArmorListener implements Listener {
                     // Move clicked item to other inventory when cancelled.
                     if (armorEvent.isCancelled()) {
                         p.getInventory().setItem(armorEvent.getArmorSlot(), armorEvent.getItem());
-                        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+                        MultiLib.getAsyncScheduler().runNow(SkyFactionsReborn.getInstance(), (consumer) -> {
                             p.getInventory().setItem(armorEvent.getArmorSlot(), null);
                             p.updateInventory();
                         });
@@ -212,7 +213,7 @@ public class ArmorListener implements Listener {
         final Player p = e.getPlayer();
         if (p.getInventory().getItem(equipmentSlot) != null) return;
 
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
+        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> {
             if (p.getInventory().getItem(equipmentSlot) != null) {
                 ArmorEvent armorEvent = callEquip(p, useItem, equipmentSlot, ArmorAction.HOTBAR);
                 // When cancelled unequip item in armor slot and put it back in the hand of the player.
@@ -222,7 +223,6 @@ public class ArmorListener implements Listener {
                 }
             }
         });
-
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/paper/src/main/java/net/skullian/skyfactions/paper/gui/items/impl/SpigotAsyncSkyItem.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/gui/items/impl/SpigotAsyncSkyItem.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.gui.items.impl;
 
+import com.github.puregero.multilib.MultiLib;
 import net.skullian.skyfactions.common.api.SkyApi;
 import net.skullian.skyfactions.common.gui.CooldownManager;
 import net.skullian.skyfactions.common.gui.data.SkyClickType;
@@ -8,7 +9,6 @@ import net.skullian.skyfactions.common.gui.items.impl.BaseSkyItem;
 import net.skullian.skyfactions.common.user.SkyUser;
 import net.skullian.skyfactions.paper.SkyFactionsReborn;
 import net.skullian.skyfactions.paper.api.adapter.SpigotAdapter;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -31,7 +31,8 @@ public class SpigotAsyncSkyItem extends AsyncSkyItem implements Item {
 
         this.IMPL = item;
         setLoading(true);
-        Bukkit.getScheduler().runTaskAsynchronously(SkyFactionsReborn.getInstance(), () -> {
+
+        MultiLib.getAsyncScheduler().runNow(SkyFactionsReborn.getInstance(), (consumer) -> {
             setLoading(false);
             notifyWindows();
         });
@@ -71,8 +72,8 @@ public class SpigotAsyncSkyItem extends AsyncSkyItem implements Item {
 
     @Override
     public void handleClick(@NotNull ClickType clickType, @NotNull Player player, @NotNull InventoryClickEvent event) {
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> {
-            event.setCancelled(true);
+        event.setCancelled(true);
+        MultiLib.getAsyncScheduler().runNow(SkyFactionsReborn.getInstance(), (consumer) -> {
             SkyUser user = SkyApi.getInstance().getUserManager().getUser(player.getUniqueId());
 
             if (CooldownManager.ITEMS.manage(user)) return;

--- a/paper/src/main/java/net/skullian/skyfactions/paper/gui/screens/SpigotScreen.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/gui/screens/SpigotScreen.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.gui.screens;
 
+import com.github.puregero.multilib.MultiLib;
 import lombok.Builder;
 import net.skullian.skyfactions.common.api.GUIAPI;
 import net.skullian.skyfactions.common.api.SkyApi;
@@ -12,7 +13,6 @@ import net.skullian.skyfactions.paper.SkyFactionsReborn;
 import net.skullian.skyfactions.paper.api.adapter.SpigotAdapter;
 import net.skullian.skyfactions.paper.gui.items.impl.SpigotAsyncSkyItem;
 import net.skullian.skyfactions.paper.gui.items.impl.SpigotSkyItem;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import xyz.xenondevs.invui.gui.Gui;
 import xyz.xenondevs.invui.window.Window;
@@ -27,7 +27,8 @@ public class SpigotScreen {
     public SpigotScreen(Screen screen) {
         this.screen = screen;
         this.builder = Gui.normal().setStructure(screen.guiData.getLAYOUT());
-        Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), this::show);
+
+        MultiLib.getGlobalRegionScheduler().run(SkyFactionsReborn.getInstance(), (consumer) -> show());
     }
 
     public void show() {

--- a/paper/src/main/java/net/skullian/skyfactions/paper/user/SpigotSkyUser.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/user/SpigotSkyUser.java
@@ -1,5 +1,6 @@
 package net.skullian.skyfactions.paper.user;
 
+import com.github.puregero.multilib.MultiLib;
 import net.kyori.adventure.sound.Sound;
 import net.kyori.adventure.text.Component;
 import net.skullian.skyfactions.common.api.SkyApi;
@@ -36,7 +37,7 @@ public class SpigotSkyUser extends SkyUser {
     public void teleport(SkyLocation location) {
         Player player = SpigotAdapter.adapt(this).getPlayer();
 
-        if (player != null) Bukkit.getScheduler().runTask(SkyFactionsReborn.getInstance(), () -> player.teleport(SpigotAdapter.adapt(location), PlayerTeleportEvent.TeleportCause.PLUGIN));
+        if (player != null) MultiLib.teleportAsync(player, SpigotAdapter.adapt(location), PlayerTeleportEvent.TeleportCause.PLUGIN);
     }
 
     @Nullable

--- a/paper/src/main/java/net/skullian/skyfactions/paper/user/SpigotSkyUser.java
+++ b/paper/src/main/java/net/skullian/skyfactions/paper/user/SpigotSkyUser.java
@@ -10,7 +10,6 @@ import net.skullian.skyfactions.common.util.SkyItemStack;
 import net.skullian.skyfactions.common.util.SkyLocation;
 import net.skullian.skyfactions.paper.SkyFactionsReborn;
 import net.skullian.skyfactions.paper.api.adapter.SpigotAdapter;
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryCloseEvent.Reason;

--- a/v1_21_R3/src/main/java/net/skullian/skyfactions/nms/v1_21_R3/NMSHandlerImpl.java
+++ b/v1_21_R3/src/main/java/net/skullian/skyfactions/nms/v1_21_R3/NMSHandlerImpl.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class NMSHandlerImpl implements NMSHandler {
 
     public NMSHandlerImpl() {
-        SLogger.setup("v1_21_R3 NMSHandler initialized.", false);
+        SLogger.setup("<#05eb2f>v1_21_R3<#4294ed> NMSHandler initialized.", false);
     }
 
     @Override

--- a/v1_21_R4/src/main/java/net/skullian/skyfactions/nms/v1_21_R4/NMSHandlerImpl.java
+++ b/v1_21_R4/src/main/java/net/skullian/skyfactions/nms/v1_21_R4/NMSHandlerImpl.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class NMSHandlerImpl implements NMSHandler {
 
     public NMSHandlerImpl() {
-        SLogger.setup("v1_21_R4 NMSHandler initialized.", false);
+        SLogger.setup("<#05eb2f>v1_21_R4<#4294ed> NMSHandler initialized.", false);
     }
 
     @Override


### PR DESCRIPTION
This PR converts all BukkitScheduler to [MultiLib](https://github.com/MultiPaper/MultiLib) schedulers.

This adds support for MultiPaper, Folia, ShreddedPaper and similar while maintaining compatibility with Paper / forks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced asynchronous handling for faction and island creation.
  - Added support for the `multilib` library to improve task scheduling and player management.
  
- **Bug Fixes**
  - Improved entity filtering logic to exclude external entities.
  
- **Documentation**
  - Updated logging messages for better visibility with color formatting.

- **Refactor**
  - Streamlined asynchronous task handling across various components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->